### PR TITLE
chore: jx-python-demo to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.112
 - name: jx-python-demo
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3
 - name: jx-spring-demo
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7


### PR DESCRIPTION
chore: Promote jx-python-demo to version 0.0.3