### PR TITLE
chore: lunchup-backend to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.7
 - name: lunchup-backend
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.4


### PR DESCRIPTION
chore: Promote lunchup-backend to version 0.0.4