### PR TITLE
chore: jx-python-demo to 0.0.10

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.112
 - name: jx-python-demo
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.9
+  version: 0.0.10
 - name: lunchup-backend
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.26


### PR DESCRIPTION
chore: Promote jx-python-demo to version 0.0.10