### PR TITLE
chore: lunchup-backend to 0.1.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.14
 - name: lunchup-backend
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.10
+  version: 0.1.11
 - name: lunchup-scheduler
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.11


### PR DESCRIPTION
chore: Promote lunchup-backend to version 0.1.11